### PR TITLE
Fix drivetrain safety

### DIFF
--- a/src/main/java/org/team199/robot2021/Robot.java
+++ b/src/main/java/org/team199/robot2021/Robot.java
@@ -48,7 +48,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
-    robotContainer.drivetrain.toggleMode();
+    robotContainer.drivetrain.brake();
     robotContainer.getAutonomousCommand().schedule();
     Log.setDataLoggingDisabled(false);
   }
@@ -64,7 +64,8 @@ public class Robot extends TimedRobot {
    * This function is called once each time the robot enters teleoperated mode.
    */
   @Override
-  public void teleopInit() {robotContainer.drivetrain.toggleMode();
+  public void teleopInit() {
+    robotContainer.drivetrain.brake();
     Log.setDataLoggingDisabled(false);
   }
 
@@ -87,7 +88,7 @@ public class Robot extends TimedRobot {
     new Thread(() -> {
       try {
         Thread.sleep(1000);
-        robotContainer.drivetrain.toggleMode();
+        robotContainer.drivetrain.coast();
       } catch(InterruptedException e) {}
     }).start();
     Log.flush();

--- a/src/main/java/org/team199/robot2021/RobotContainer.java
+++ b/src/main/java/org/team199/robot2021/RobotContainer.java
@@ -119,7 +119,8 @@ public class RobotContainer {
                 () -> SmartDashboard.putBoolean("Characterized Drive", !SmartDashboard.getBoolean("Characterized Drive", false))));
     }
 
-    private void configureButtonBindingsRightJoy() {new JoystickButton(rightJoy, 3).whenPressed(new InstantCommand(drivetrain::toggleMode, drivetrain));
+    private void configureButtonBindingsRightJoy() {
+        new JoystickButton(rightJoy, 3).whenPressed(new InstantCommand(drivetrain::toggleMode, drivetrain));
         // Align the robot and then shoots
         new JoystickButton(rightJoy, Constants.OI.RightJoy.kAlignAndShootButton).whileHeld(new SequentialCommandGroup(new ShooterHorizontalAim(drivetrain, lime), new Shoot(feeder)));
     }

--- a/src/main/java/org/team199/robot2021/subsystems/Drivetrain.java
+++ b/src/main/java/org/team199/robot2021/subsystems/Drivetrain.java
@@ -16,7 +16,7 @@ import frc.robot.lib.MotorControllerFactory;
 import org.team199.robot2021.Constants;
 
 import edu.wpi.first.wpilibj.Timer;
-
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
@@ -146,15 +146,25 @@ public class Drivetrain extends SubsystemBase {
 
   public void toggleMode() {
     if(leftMaster.getIdleMode() == IdleMode.kBrake) {
+      brake();
+    } else {
+      coast();
+    }
+  }
+
+  public void brake() {
+    leftMaster.setIdleMode(IdleMode.kBrake);
+    leftSlave.setIdleMode(IdleMode.kBrake);
+    rightMaster.setIdleMode(IdleMode.kBrake);
+    rightSlave.setIdleMode(IdleMode.kBrake);
+  }
+
+  public void coast() {
+    if(DriverStation.getInstance().isDisabled()) {
       leftMaster.setIdleMode(IdleMode.kCoast);
       leftSlave.setIdleMode(IdleMode.kCoast);
       rightMaster.setIdleMode(IdleMode.kCoast);
       rightSlave.setIdleMode(IdleMode.kCoast);
-    } else {
-      leftMaster.setIdleMode(IdleMode.kBrake);
-      leftSlave.setIdleMode(IdleMode.kBrake);
-      rightMaster.setIdleMode(IdleMode.kBrake);
-      rightSlave.setIdleMode(IdleMode.kBrake);
     }
   }
 


### PR DESCRIPTION
The drivetrain is programed to disable brake mode on the drivetrain while disabled. Unfortunately, this created a few cases where it was possible to put the drivetrain into coast mode while enabled. This is obviously not good practice. This PR should remove those cases by switching the system to be based on an absolute state and forcibly disabling coast functionality while enabled.